### PR TITLE
feat: Agregar variables SCSS para tamaños de fuente

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-browser": "^17.2.1",
         "@angular/platform-browser-dynamic": "^17.2.1",
         "@angular/router": "^17.2.1",
+        "@fontsource/poppins": "^5.1.0",
         "@fortawesome/angular-fontawesome": "^0.14.1",
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
@@ -2817,6 +2818,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@fontsource/poppins": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/poppins/-/poppins-5.1.0.tgz",
+      "integrity": "sha512-tpLXlnNi2fwQjiipvuj4uNFHCdoLA8izRsKdoexZuEzjx0r/g1aKLf4ta6lFgF7L+/+AFdmaXFlUwwvmDzYH+g==",
+      "license": "OFL-1.1"
     },
     "node_modules/@fortawesome/angular-fontawesome": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^17.2.1",
     "@angular/platform-browser-dynamic": "^17.2.1",
     "@angular/router": "^17.2.1",
+    "@fontsource/poppins": "^5.1.0",
     "@fortawesome/angular-fontawesome": "^0.14.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/src/base.scss
+++ b/src/base.scss
@@ -1,0 +1,54 @@
+// src/styles/base.scss
+
+
+body {
+    font-family: $font-family-primary;
+    font-size: $font-size-paragraph;
+    line-height: $line-height-base;
+}
+
+h1 {
+    font-size: $font-size-h1;
+    font-weight: $font-weight-bold;
+    line-height: $line-height-heading;
+}
+
+h2 {
+    font-size: $font-size-h2;
+    font-weight: $font-weight-bold;
+}
+
+h3 {
+    font-size: $font-size-h3;
+    font-weight: $font-weight-normal;
+}
+
+h4 {
+    font-size: $font-size-h4;
+    font-weight: $font-weight-normal;
+}
+
+h5 {
+    font-size: $font-size-h5;
+    font-weight: $font-weight-normal;
+}
+
+h6 {
+    font-size: $font-size-h6;
+    font-weight: $font-weight-normal;
+}
+
+.title {
+    font-size: $font-size-title;
+    font-weight: $font-weight-bold;
+}
+
+.section {
+    font-size: $font-size-section;
+    font-weight: $font-weight-normal;
+}
+
+.caption {
+    font-size: $font-size-caption;
+    font-weight: $font-weight-normal;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 @import '~@fortawesome/fontawesome-free/css/all.min.css';
+@import '~@fontsource/poppins/index.css';
+@import 'typography';
+@import 'base';
+@import "@fontsource/poppins"; // Defaults to weight 400
+@import "@fontsource/poppins/400.css"; // Specify weight
+@import "@fontsource/poppins/400-italic.css"; // Specify weight and style
 
 * {
     margin: 0;

--- a/src/typography.scss
+++ b/src/typography.scss
@@ -1,0 +1,26 @@
+// src/styles/_variables.scss
+
+// Fuente principal
+$font-family-primary: 'Poppins';
+
+// Tamaños de fuente
+$font-size-h1: 2rem;
+$font-size-h2: 1.75rem;
+$font-size-h3: 1.5rem;
+$font-size-h4: 1.25rem;
+$font-size-h5: 1rem;
+$font-size-h6: 0.875rem;
+$font-size-title: 1.25rem;
+$font-size-section: 1.125rem;
+$font-size-paragraph: 1rem;
+$font-size-caption: 0.75rem;
+
+// Pesos de fuente
+$font-weight-light: 300;
+$font-weight-normal: 400;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
+
+// Altura de línea
+$line-height-base: 1.4;
+$line-height-heading: 1.25;


### PR DESCRIPTION
- Se añadieron variables para varios tamaños de fuente, incluyendo encabezados, títulos, secciones, párrafos y leyendas.
- Se actualizaron los estilos base para utilizar las nuevas variables de tamaño de fuente.